### PR TITLE
Don't use class variable in We::Call::Deprecated

### DIFF
--- a/lib/we/call/deprecated.rb
+++ b/lib/we/call/deprecated.rb
@@ -3,22 +3,22 @@ require "ruby_decorators"
 module We
   module Call
     class Deprecated < RubyDecorator
-      @@methods = {}
+      class << self
+        private def methods
+          @methods ||= {}
+        end
+      end
 
       def initialize(date:)
         @date = date
       end
 
       def set(method, value)
-        @@methods[method] = value
+        self.class.methods[method] = value
       end
 
       def self.get(method)
-        @@methods[method]
-      end
-
-      def self.methods
-        @@methods
+        methods[method]
       end
 
       # Called when annotation is used


### PR DESCRIPTION
This commit removes the class variable in `We::Call::Deprecated` and changes it for one in the singleton class (thread safe by default).