### PR TITLE
Switched to typheous by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ _For now this gem requires Rails 4.2+ due to some ActiveController functionality
 - [ ] Support adding href to Deprecate to make a `Link` with rel=sunset as per Sunset RFC draft 03
 - [ ] Remove Rails as a dependency (soft requirement on `ActiveSupport::Deprecated` is fine)
 - [x] Split DetectDeprecations into standalone [faraday-sunset] gem
-- [ ] Pass Trace IDs along
 - [ ] Work on sane defaults for retries and error raising
 
 [faraday-sunset]: https://github.com/philsturgeon/faraday-sunset
@@ -167,12 +166,12 @@ _For now this gem requires Rails 4.2+ due to some ActiveController functionality
 To run tests and modify locally, you'll want to `bundle install` in this directory.
 
 ```
-bundle exec rspec
+bundle exec appraisal rspec
 ```
 
 ## Development
 
-If you want to test this gem within an application, update your Gemfile to have something like this: `gem 'we-call', github: 'wework/we-call', branch: 'BRANCHNAME'` and set your local config: `bundle config --local local.we-call path/to/we-call`
+If you want to test this gem within an application, update your Gemfile to have something like this: `gem 'we-call', github: 'wework/we-call-gem', branch: 'BRANCHNAME'` and set your local config: `bundle config --local local.we-call path/to/we-call-gem`
 
 Simply revert the Gemfile change (updating the version as necessary!) and remove the config with `bundle config --delete local.we-call`.
 

--- a/spec/integration/we/call/connection_spec.rb
+++ b/spec/integration/we/call/connection_spec.rb
@@ -38,40 +38,4 @@ RSpec.describe We::Call::Connection do
       end
     end
   end
-
-  context 'adapter configuration' do
-    context 'when no adapter is specified' do
-      subject do
-        described_class.new(host: 'http://pokeapi.co/api/v2/', app: 'pokedex', env: 'test', timeout: 5)
-      end
-
-      it 'should have the default adapter' do
-        expect(subject.builder.handlers.map(&:klass)).to contain_exactly(Faraday::Adapter::NetHttp, Faraday::Sunset)
-      end
-    end
-
-    context 'when default adapter is specified' do
-      subject do
-        described_class.new(host: 'http://pokeapi.co/api/v2/', app: 'pokedex', env: 'test', timeout: 5) do |conn|
-          conn.adapter Faraday.default_adapter
-        end
-      end
-
-      it 'only has Faraday.default_adapter adapter handler' do
-        expect(subject.builder.handlers.map(&:klass)).to contain_exactly(Faraday::Adapter::NetHttp, Faraday::Sunset)
-      end
-    end
-
-    context 'when :net_http_persistent adapter is specified' do
-      subject do
-        described_class.new(host: 'http://pokeapi.co/api/v2/', app: 'pokedex', env: 'test', timeout: 5) do |conn|
-          conn.adapter :net_http_persistent
-        end
-      end
-
-      it 'only has NetHttpPersistent adapter handler' do
-        expect(subject.builder.handlers.map(&:klass)).to contain_exactly(Faraday::Adapter::NetHttpPersistent, Faraday::Sunset)
-      end
-    end
-  end
 end

--- a/spec/unit/we/call/connection_spec.rb
+++ b/spec/unit/we/call/connection_spec.rb
@@ -119,19 +119,19 @@ RSpec.describe We::Call::Connection do
         end
 
         it 'should have the default adapter' do
-          expect(subject.builder.handlers.map(&:klass)).to contain_exactly(Faraday::Adapter::NetHttp, Faraday::Sunset)
+          expect(subject.builder.handlers.map(&:klass)).to contain_exactly(described_class::DEFAULT_ADAPTER_CLASS, Faraday::Sunset)
         end
       end
 
       context 'when default adapter is specified' do
         subject do
           described_class.new(host: 'http://pokeapi.co/api/v2/', app: 'pokedex', env: 'test', timeout: 5) do |conn|
-            conn.adapter Faraday.default_adapter
+            conn.adapter described_class::DEFAULT_ADAPTER
           end
         end
 
-        it 'only has Faraday.default_adapter adapter handler' do
-          expect(subject.builder.handlers.map(&:klass)).to contain_exactly(Faraday::Adapter::NetHttp, Faraday::Sunset)
+        it 'is not repeated adapter handler' do
+          expect(subject.builder.handlers.map(&:klass)).to contain_exactly(described_class::DEFAULT_ADAPTER_CLASS, Faraday::Sunset)
         end
       end
 

--- a/we-call.gemspec
+++ b/we-call.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.bindir               = "bin"
   spec.require_paths        = ["lib"]
 
-  spec.add_dependency "faraday", ">= 0.9.0", "< 0.14"
+  spec.add_dependency "typhoeus", "~> 1.3"
+  spec.add_dependency "faraday", ">= 0.9.0", "< 1.0"
   spec.add_dependency "faraday_middleware", '~> 0'
   spec.add_dependency "faraday-sunset", "~> 0.1.0"
   spec.add_dependency "ruby_decorators", '~> 0.0'


### PR DESCRIPTION
NetHTTP is automatically retrying things and there is no way to make it stop short of monkey patching NetHTTP to empty out the IDEMPOTENT_METHOD array... 

https://github.com/lostisland/faraday/issues/612

NetHTTP has been doing this crap [since 2012](https://github.com/ruby/ruby/commit/bee7ccddd254c7b6e781f5ea9bbf651b50b590ee), and the [PR to make it configurable](https://github.com/ruby/ruby/pull/1654) isn't coming [until Ruby 2.5.0](https://github.com/ruby/ruby/commit/4f4d7247208b467c3d48587d10761c23a41b140b).

Until the majority of apps (at WeWork and... everywhere) are using Ruby 2.5.0, we cannot stop this from happening. 

Everyone I've  spoken to this is shocked, scared, and angry. We've been wondering why a 10s timeout was taking 20s, and NewRelic, etc, everywhere shows this as one connection. It's daft and dangerous. 

Let's advocate the use of the fantastic (and optional) `faraday.response :retry, max: 1` instead, so people know what's happening.