### PR TITLE
Add gzip middleware to adapters that dont handle it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+we-call-*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.7.1] - 2018-02-20
+### Fixed
+- Call the gzip middleware to handle gzipped responses, which have been broken since v0.7 for typhoeus users
+
 ## [v0.7.0] - 2017-10-07
 ### Breaking Changes
 - Removed `We::Call::Deprecated` and `We::Call::Annotations`. Deprecation logic is now handled by [rails-sunset] instead. I fully understand the irony of removing deprecation logic without deprecation

--- a/lib/we/call.rb
+++ b/lib/we/call.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday_middleware'
 require 'faraday-sunset'
 require 'typhoeus'
 

--- a/lib/we/call/version.rb
+++ b/lib/we/call/version.rb
@@ -1,5 +1,5 @@
 module We
   module Call
-    VERSION = "0.7.0"
+    VERSION = "0.7.1"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,10 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'coveralls'
 require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 SimpleCov.start do
   add_group 'lib', 'lib'
 end

--- a/we-call.gemspec
+++ b/we-call.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.require_paths        = ["lib"]
 
   spec.add_dependency "typhoeus", "~> 1.3"
-  spec.add_dependency "faraday", ">= 0.9.0", "< 1.0"
-  spec.add_dependency "faraday_middleware", '~> 0'
+  spec.add_dependency "faraday", ">= 0.9.0", "< 1"
+  spec.add_dependency "faraday_middleware", '~> 0.10'
   spec.add_dependency "faraday-sunset", "~> 0.1.0"
 
-  spec.add_development_dependency "appraisal", "~> 2"
+  spec.add_development_dependency "appraisal", "~> 2.0"
   spec.add_development_dependency "coveralls", '~> 0.7'
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "simplecov", '~> 0.15'
   spec.add_development_dependency "hashie", "~> 3.5"
-  spec.add_development_dependency "vcr", '~> 3'
+  spec.add_development_dependency "vcr", '~> 3.0'
 end


### PR DESCRIPTION
Since the switch to Typheous in v0.7.0, we-call has not been handling gzip content. This adds it back.

Only some faraday adapters bother to decode gzip content, so luckily there is a middleware and we can do a little detection to see if we should enable it or not. [Related](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/gzip.rb#L9).