### PR TITLE
[ActiveSupport Auto] Deprecation Detection Changes

### DIFF
--- a/lib/we/call/configuration.rb
+++ b/lib/we/call/configuration.rb
@@ -9,7 +9,7 @@ module We
       def initialize
         @app_env_header = 'X-App-Env'
         @app_name_header = 'X-App-Name'
-        @detect_deprecations = :active_support
+        @detect_deprecations = nil
       end
     end
   end

--- a/lib/we/call/connection.rb
+++ b/lib/we/call/connection.rb
@@ -110,11 +110,9 @@ module We
       end
 
       def setup_sunset_middleware(faraday)
-        options = { rollbar: :auto }
-        if config.detect_deprecations == :active_support
-          options = options.merge({ active_support: true })
+        options = { rollbar: :auto, active_support: :auto }
         # Pass something that might be a logger or anything with a warn method
-        elsif config.detect_deprecations.respond_to?(:warn)
+        if config.detect_deprecations.respond_to?(:warn)
           options = options.merge({ logger: config.detect_deprecations })
         end
         options

--- a/lib/we/call/version.rb
+++ b/lib/we/call/version.rb
@@ -1,5 +1,5 @@
 module We
   module Call
-    VERSION = "0.8.0"
+    VERSION = "0.9.0"
   end
 end

--- a/spec/unit/we/call/configuration_spec.rb
+++ b/spec/unit/we/call/configuration_spec.rb
@@ -43,15 +43,15 @@ RSpec.describe We::Call::Configuration do
   end
 
   describe "#detect_deprecations" do
-    it "default value is :active_support" do
-      expect(subject.detect_deprecations).to be :active_support
+    it "default value is nil" do
+      expect(subject.detect_deprecations).to be_nil
     end
   end
 
   describe "#detect_deprecations=" do
     it "can set value" do
-      subject.detect_deprecations = false
-      expect(subject.detect_deprecations).to be false
+      subject.detect_deprecations = true
+      expect(subject.detect_deprecations).to be true
     end
   end
 end

--- a/spec/unit/we/call/connection_spec.rb
+++ b/spec/unit/we/call/connection_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe We::Call::Connection do
       let(:handlers) { subject.builder.handlers.map(&:klass) }
 
       context 'when no adapter is specified' do
+
+        before do
+          We::Call::configuration.detect_deprecations = true
+        end
+
         subject do
           described_class.new(host: 'http://pokeapi.co/api/v2/', app: 'pokedex', env: 'test', timeout: 5)
         end
@@ -179,17 +184,18 @@ RSpec.describe We::Call::Connection do
         let(:builder_spy) { spy('QueryableBuilder') }
 
         before do
+          We::Call::configuration.detect_deprecations = true
           allow(We::Call::Connection::QueryableBuilder).to receive(:new) { builder_spy }
           allow(builder_spy).to receive(:use)
           allow(builder_spy).to receive(:response)
         end
 
         context 'and config.detect_deprecations is left to default' do
-          it 'register middleware with { active_support: true }' do
+          it 'register middleware with { active_support: :auto }' do
             subject
             expect(builder_spy).to have_received(:response).with(
               :sunset,
-              active_support: true,
+              active_support: :auto,
               rollbar: :auto
             )
           end
@@ -212,7 +218,8 @@ RSpec.describe We::Call::Connection do
             expect(builder_spy).to have_received(:response).with(
               :sunset,
               logger: logger,
-              rollbar: :auto
+              rollbar: :auto,
+              active_support: :auto
             )
           end
         end


### PR DESCRIPTION
- Default to `detect_deprecations: nil` in config
- Default to `active_support: :auto` when setting up sunset middleware