### PR TITLE
Module#parent_name deprecation warnings for rails 6

### DIFF
--- a/lib/we/call/connection.rb
+++ b/lib/we/call/connection.rb
@@ -136,7 +136,7 @@ module We
 
       def rails_app_name
         if (defined? ::Rails) && !::Rails.application.nil?
-          ::Rails.application.class.parent_name.underscore.dasherize
+          ::Rails.application.class.module_parent_name.underscore.dasherize
         end
       end
     end


### PR DESCRIPTION
A straightforward fix for the deprecation warning below:

`DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1. `