### PR TITLE
CW-2810 Retry on network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,36 @@ As well as `timeout: num_seconds` which can set the entire open/read (essentiall
 
 ### Client
 
+**Retry**
+
+Automatically enabled, the retry middleware will retry the request in case of network errors. By default, the middleware will retry up to 3 times, waiting 1 second between the retries.
+
+Disable the middleware:
+
+```ruby
+We::Call.configure do |config|
+  config.retry = false
+end
+```
+
+Adjust the middleware:
+
+```ruby
+We::Call.configure do |config|
+  config.retry_options = { interval: 0.5 }
+end
+```
+
+The gem smartly merges the options passed, so you can specify your own list of exceptions without being afraid to override the default ones:
+
+```ruby
+We::Call.configure do |config|
+  config.retry_options = { exceptions: [Faraday::ResourceNotFound] }
+end
+```
+
+Check [Faraday's Retry Docs](https://github.com/lostisland/faraday/blob/master/docs/middleware/request/retry.md) for a list of available options.
+
 **DetectDeprecations**
 
 Automatically enabled, the faraday-sunset middleware will watch for the [Sunset header](https://tools.ietf.org/html/draft-wilde-sunset-header-03) and send warning to `ActiveSupport::Deprecation` if enabled, or to whatever is in `ENV['rake.logger']`.

--- a/lib/we/call/configuration.rb
+++ b/lib/we/call/configuration.rb
@@ -4,11 +4,14 @@ require 'faraday_middleware'
 module We
   module Call
     class Configuration
-      attr_accessor :app_env, :app_env_header, :app_name, :app_name_header, :detect_deprecations
+      attr_accessor :app_env, :app_env_header, :app_name, :app_name_header, :detect_deprecations,
+                    :retry, :retry_options
 
       def initialize
         @app_env_header = 'X-App-Env'
         @app_name_header = 'X-App-Name'
+        @retry = true
+        @retry_options = {}
       end
     end
   end

--- a/lib/we/call/version.rb
+++ b/lib/we/call/version.rb
@@ -1,5 +1,5 @@
 module We
   module Call
-    VERSION = "0.9.0"
+    VERSION = "0.10.0"
   end
 end

--- a/spec/unit/we/call/configuration_spec.rb
+++ b/spec/unit/we/call/configuration_spec.rb
@@ -54,4 +54,18 @@ RSpec.describe We::Call::Configuration do
       expect(subject.detect_deprecations).to be true
     end
   end
+
+  describe "#retry" do
+    it "can set value" do
+      subject.retry = true
+      expect(subject.retry).to be true
+    end
+  end
+
+  describe "#retry_options=" do
+    it "can set value" do
+      subject.retry_options = { max: 5 }
+      expect(subject.retry_options).to eq({ max: 5 })
+    end
+  end
 end


### PR DESCRIPTION
Network connections can be unstable ~~these days~~ - a good practice is to wrap all HTTP interactions in retry blocks.

This adds Faraday's default Retry middleware to all requests.
Additionally, I would suggest to decrease the default [open timeout](https://github.com/wework/we-call-gem/blob/master/lib/we/call/connection.rb#L10) to 0.5 seconds.