### PR TITLE
Rails 6.1 fix

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -22,6 +22,14 @@ appraise "faraday-0.10" do
   gem "faraday", "~> 0.10.0"
 end
 
+appraise "rails-6.1" do
+  gem "rails", "~> 6.1.0"
+end
+
+appraise "rails-6.0" do
+  gem "rails", "~> 6.0.0"
+end
+
 appraise "rails-5.2" do
   gem "rails", "~> 5.2.0"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.12.1] - 2021-06-11
+### Fixed
+- Change the method to guess `rails_app_name` to work correctly across different Rails versions
+
 ## [v0.12.0] - 2020-12-17
 ### Added
 - Bump version to fix incorrect tag

--- a/lib/we/call/connection.rb
+++ b/lib/we/call/connection.rb
@@ -162,7 +162,7 @@ module We
 
       def rails_app_name
         if (defined? ::Rails) && !::Rails.application.nil?
-          ::Rails.application.class.parent_name.underscore.dasherize
+          ::Rails.application.class.name.deconstantize.underscore.dasherize
         end
       end
     end

--- a/lib/we/call/version.rb
+++ b/lib/we/call/version.rb
@@ -1,5 +1,5 @@
 module We
   module Call
-    VERSION = "0.12.0"
+    VERSION = "0.12.1"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,5 @@ VCR.configure do |config|
   config.configure_rspec_metadata!
 end
 
+require 'rails'
 require 'we/call'

--- a/spec/unit/we/call/connection_spec.rb
+++ b/spec/unit/we/call/connection_spec.rb
@@ -91,14 +91,25 @@ RSpec.describe We::Call::Connection do
     end
 
     context 'when app needs to be guessed' do
-      before { allow_any_instance_of(described_class).to receive(:rails_app_name) { 'test-app' } }
+      before do
+        allow(Rails).to receive(:application).and_return(app_class.new)
+      end
 
-      let(:valid_arguments_without_env) { valid_arguments.tap { |h| h.delete(:app) } }
+      let(:valid_arguments_without_app) { valid_arguments.tap { |h| h.delete(:app) } }
+      let(:app_class) { stub_const('WeCallTest::Application', Class.new) }
 
-      subject { described_class.new(**valid_arguments_without_env) }
+      subject { described_class.new(**valid_arguments_without_app) }
 
       it 'contains X-App-Name header' do
-        expect(subject.headers['X-App-Name']).to eql('test-app')
+        expect(subject.headers['X-App-Name']).to eql('we-call-test')
+      end
+
+      context 'when app has only one segment' do
+        let(:app_class) { stub_const('Test::Application', Class.new) }
+
+        it 'contains X-App-Name header' do
+          expect(subject.headers['X-App-Name']).to eql('test')
+        end
       end
     end
 


### PR DESCRIPTION
`Module#parent_name` has been removed in Rails 6.1. The method is now called `module_parent_name`.

Instead of calling different methods based on Rails version it makes sense to use [deconstantize](https://api.rubyonrails.org/classes/String.html#method-i-deconstantize), which was there from at least Rails 3.